### PR TITLE
Added parameter to force fresh response

### DIFF
--- a/src/providers/facebook.ts
+++ b/src/providers/facebook.ts
@@ -114,9 +114,10 @@ export class FacebookService {
 
   /**
    * This method allows you to determine if a user is logged in to Facebook and has authenticated your app.
+   * @param [forceFreshResponse=false] {boolean} Force a fresh response.
    * @returns {Promise<LoginStatus>}
    */
-  getLoginStatus(forceFreshResponse: boolean): Promise<LoginStatus> {
+  getLoginStatus(forceFreshResponse?: boolean): Promise<LoginStatus> {
     return new Promise<LoginStatus>((resolve, reject) => {
 
       try {

--- a/src/providers/facebook.ts
+++ b/src/providers/facebook.ts
@@ -116,7 +116,7 @@ export class FacebookService {
    * This method allows you to determine if a user is logged in to Facebook and has authenticated your app.
    * @returns {Promise<LoginStatus>}
    */
-  getLoginStatus(): Promise<LoginStatus> {
+  getLoginStatus(forceFreshResponse: boolean): Promise<LoginStatus> {
     return new Promise<LoginStatus>((resolve, reject) => {
 
       try {
@@ -126,7 +126,7 @@ export class FacebookService {
           } else {
             resolve(response);
           }
-        });
+        }, forceFreshResponse);
       } catch (e) {
         reject(e);
       }


### PR DESCRIPTION
Necessary in case a token has been invalidated and the page hasn't been refreshed since.

Ref issue https://github.com/zyra/ngx-facebook/issues/106